### PR TITLE
Remove frame_type from the header type

### DIFF
--- a/lib/types.ml
+++ b/lib/types.ml
@@ -337,11 +337,7 @@ let clear_exclusive id = clear_bit id 31
 
 type data_frame = string
 
-type frame_header =
-  { length : int
-  ; frame_type : frame_type_id
-  ; flags : frame_flags
-  ; stream_id : stream_id }
+type frame_header = {length : int; flags : frame_flags; stream_id : stream_id}
 
 type frame_payload =
   | DataFrame of data_frame
@@ -355,5 +351,18 @@ type frame_payload =
   | WindowUpdateFrame of window_size
   | ContinuationFrame of string
   | UnknownFrame of frame_type * string
+
+let frame_payload_to_frame_id = function
+  | DataFrame _ -> FrameData
+  | HeadersFrame _ -> FrameHeaders
+  | PriorityFrame _ -> FramePriority
+  | RSTStreamFrame _ -> FrameRSTStream
+  | SettingsFrame _ -> FrameSettings
+  | PushPromiseFrame _ -> FramePushPromise
+  | PingFrame _ -> FramePing
+  | GoAwayFrame _ -> FrameGoAway
+  | WindowUpdateFrame _ -> FrameWindowUpdate
+  | ContinuationFrame _ -> FrameContinuation
+  | UnknownFrame (x, _) -> FrameUnknown x
 
 type frame = {frame_header : frame_header; frame_payload : frame_payload}

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -184,11 +184,7 @@ val clear_exclusive : stream_id -> stream_id
 (** FrameHeader is the 9 byte header of all HTTP/2 frames. See:
     {{:http://http2.github.io/http2-spec/#FrameHeader}
     http://http2.github.io/http2-spec/#FrameHeader}*)
-type frame_header =
-  { length : int
-  ; frame_type : frame_type_id
-  ; flags : frame_flags
-  ; stream_id : stream_id }
+type frame_header = {length : int; flags : frame_flags; stream_id : stream_id}
 
 type data_frame = string
 
@@ -204,5 +200,7 @@ type frame_payload =
   | WindowUpdateFrame of window_size
   | ContinuationFrame of string
   | UnknownFrame of frame_type * string
+
+val frame_payload_to_frame_id : frame_payload -> frame_type_id
 
 type frame = {frame_header : frame_header; frame_payload : frame_payload}

--- a/test/data_frame_test.ml
+++ b/test/data_frame_test.ml
@@ -8,10 +8,6 @@ let wire_no_padding = "0000080001000000017465737464617461"
 
 let extract_payload = function DataFrame x -> x | _ -> failwith "BAD PAYLOAD"
 
-let expected_frame =
-  { frame_header = {length = 20; frame_type = FrameData; flags = 8; stream_id = 2}
-  ; frame_payload = DataFrame "Hello, world!" }
-
 let parse_data_frame_with_padding () =
   let parsed = Util.parse_success wire in
   Alcotest.(check int) "Header flags" 8 parsed.frame_header.flags ;

--- a/test/priority_frame_test.ml
+++ b/test/priority_frame_test.ml
@@ -18,9 +18,6 @@ let parse_priority_frame () =
   (* First frame *)
   Alcotest.(check int) "Flags" 0 parsed.frame_header.flags ;
   Alcotest.(check int) "Stream id" 9 parsed.frame_header.stream_id ;
-  Alcotest.(check int)
-    "Frame type" 2
-    (frame_type_of_id parsed.frame_header.frame_type) ;
   Alcotest.(check int) "length" 5 parsed.frame_header.length ;
   Alcotest.(check int) "Stream dependency" 11 payload.stream_dependency ;
   Alcotest.(check int) "Weight" 7 payload.weight ;

--- a/test/rst_stream_frame_test.ml
+++ b/test/rst_stream_frame_test.ml
@@ -15,7 +15,6 @@ let parse_rst_frame () =
   Alcotest.(check int) "Length" 4 parsed.frame_header.length ;
   Alcotest.(check int) "flags" 0 parsed.frame_header.flags ;
   Alcotest.(check int) "stream id" 5 parsed.frame_header.stream_id ;
-  Alcotest.(check int) "type" 3 (frame_type_of_id parsed.frame_header.frame_type) ;
   Alcotest.(check int) "Error code" 8 (error_code_of_id error)
 
 let parse_rst_frame' () =
@@ -24,7 +23,6 @@ let parse_rst_frame' () =
   Alcotest.(check int) "Length" 4 parsed.frame_header.length ;
   Alcotest.(check int) "flags" 0 parsed.frame_header.flags ;
   Alcotest.(check int) "stream id" 1 parsed.frame_header.stream_id ;
-  Alcotest.(check int) "type" 3 (frame_type_of_id parsed.frame_header.frame_type) ;
   Alcotest.(check int) "Error code" 420 (error_code_of_id error)
 
 let tests =


### PR DESCRIPTION
No need to keep the type stored there. We can deduce it from the payload type