### PR TITLE
Simplify parser.

### DIFF
--- a/frames/lib/parse.ml
+++ b/frames/lib/parse.ml
@@ -2,85 +2,6 @@ open Base
 open Angstrom
 open Types
 
-let zero_frame_types = [FrameSettings; FramePing; FrameGoAway]
-
-let non_zero_frame_types =
-  [ FrameData
-  ; FrameHeaders
-  ; FramePriority
-  ; FrameRSTStream
-  ; FramePushPromise
-  ; FrameContinuation ]
-
-(* TODO: Go back and verify all these checks against spec. *)
-let check_frame_header settings frame_header frame_type =
-  let open Polymorphic_compare in
-  let {enable_push; _} = settings in
-  let {flags; length; stream_id} = frame_header in
-  let check_frame_type = function
-    | FrameData when stream_id = 0x0 ->
-        Error
-          (ConnectionError
-             (ProtocolError, "data frames must be associated with a stream"))
-    | FrameHeaders when test_padded flags && length < 1 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "insufficient payload for padding length"))
-    | FrameHeaders when test_priority flags && length < 5 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "insufficient payload for priority fields"))
-    | FrameHeaders when test_padded flags && test_priority flags && length < 6 ->
-        Error
-          (ConnectionError
-             ( FrameSizeError
-             , "insufficient payload for Pad length and priority fields" ))
-    | FramePriority when length <> 5 ->
-        Error (StreamError (FrameSizeError, stream_id))
-    | FrameRSTStream when length <> 4 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "payload length is not 4 in rst stream frame"))
-    | FrameSettings when length % 6 <> 0 ->
-        Error
-          (ConnectionError
-             ( FrameSizeError
-             , "payload length is not multiple of 6 in settings frame" ))
-    | FrameSettings when test_ack flags && length <> 0 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "payload length must be 0 if ack flag is set"))
-    | FramePushPromise when not enable_push ->
-        Error (ConnectionError (ProtocolError, "push not enabled"))
-    | FramePushPromise when not (is_response stream_id) ->
-        Error
-          (ConnectionError
-             (ProtocolError, "push promise must be used with response streams"))
-    | FramePing when length <> 8 ->
-        Error
-          (ConnectionError (FrameSizeError, "payload length is 8 in ping frame"))
-    | FrameGoAway when length < 8 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "go away body must be 8 bytes or more"))
-    | FrameWindowUpdate when length <> 4 ->
-        Error
-          (ConnectionError
-             (FrameSizeError, "payload length is 4 in window update frame"))
-    | _ -> Ok {flags; length; stream_id}
-  in
-  if length > settings.max_frame_size then
-    Error (ConnectionError (FrameSizeError, "exceeded maximum frame size"))
-  else if
-    List.exists ~f:(fun x -> x = frame_type) non_zero_frame_types
-    && is_control stream_id
-  then Error (ConnectionError (ProtocolError, "cannot use in control stream"))
-  else if
-    List.exists ~f:(fun x -> x = frame_type) zero_frame_types
-    && not (is_control stream_id)
-  then Error (ConnectionError (ProtocolError, "cannot use in non-zero stream"))
-  else check_frame_type frame_type
-
 let frame_length =
   lift3
     (fun x y z -> (x lsl 16) lor (y lsl 8) lor z)
@@ -93,28 +14,18 @@ let frame_flags = any_uint8
 let stream_identifier =
   lift (fun x -> Int32.to_int_exn x land ((1 lsl 31) - 1)) Angstrom.BE.any_int32
 
-let parse_frame_header =
-  lift4
-    (fun length frame_type flags stream_id ->
-      (frame_type, {flags; length; stream_id}) )
-    frame_length frame_type frame_flags stream_identifier
-
 let parse_payload_with_padding frame_header parse_fn =
   if test_padded frame_header.flags then
     any_uint8
     >>= fun pad_length ->
     let body_lenth = frame_header.length - pad_length - 1 in
     if body_lenth < 0 then
-      return
-        (Error
-           (ConnectionError
-              ( ProtocolError
-              , "padding is not enough" ^ " " ^ Int.to_string pad_length )))
+      fail ("padding is not enough " ^ Int.to_string pad_length)
     else parse_fn body_lenth
   else parse_fn frame_header.length
 
 let parse_data_frame frame_header =
-  let parse_data length = lift (fun x -> Ok (DataFrame x)) (take length) in
+  let parse_data length = lift (fun x -> DataFrame x) (take length) in
   parse_payload_with_padding frame_header parse_data
 
 let parse_priority =
@@ -128,23 +39,23 @@ let parse_priority =
       p )
     Angstrom.BE.any_int32 any_uint8
 
-let parse_priority_frame = parse_priority >>| fun x -> Ok (PriorityFrame x)
+let parse_priority_frame = parse_priority >>| fun x -> PriorityFrame x
 
 let parse_header_frame frame_header =
   let parse_fn =
     if test_priority frame_header.flags then fun length ->
       lift2
-        (fun priority headers -> Ok (HeadersFrame (Some priority, headers)))
+        (fun priority headers -> HeadersFrame (Some priority, headers))
         parse_priority
         (take (length - 5))
-    else fun length -> lift (fun x -> Ok (HeadersFrame (None, x))) (take length)
+    else fun length -> lift (fun x -> HeadersFrame (None, x)) (take length)
   in
   parse_payload_with_padding frame_header parse_fn
 
 let parse_error_code =
   lift (fun x -> error_code_to_id (Int32.to_int_exn x)) Angstrom.BE.any_int32
 
-let parse_rst_stream = lift (fun x -> Ok (RSTStreamFrame x)) parse_error_code
+let parse_rst_stream = lift (fun x -> RSTStreamFrame x) parse_error_code
 
 let parse_settings_frame frame_header =
   let num_settings = frame_header.length / 6 in
@@ -156,7 +67,7 @@ let parse_settings_frame frame_header =
       BE.any_int16 BE.any_int32
   in
   lift
-    (fun s -> Ok (SettingsFrame (List.filter_opt s)))
+    (fun s -> SettingsFrame (List.filter_opt s))
     (* TODO: This ignores unknown settings, check if this needs to be a protocol
        error. *)
     (count num_settings parse_setting)
@@ -164,34 +75,32 @@ let parse_settings_frame frame_header =
 let parse_push_promise_frame frame_header =
   let parse_fn length =
     lift2
-      (fun s h -> Ok (PushPromiseFrame (s, h)))
+      (fun s h -> PushPromiseFrame (s, h))
       stream_identifier
       (take (length - 4))
   in
   parse_payload_with_padding frame_header parse_fn
 
-let parse_ping_frame = lift (fun x -> Ok (PingFrame x)) (take 8)
+let parse_ping_frame = lift (fun x -> PingFrame x) (take 8)
 
 let parse_go_away frame_header =
   lift3
-    (fun s e x -> Ok (GoAwayFrame (s, e, x)))
+    (fun s e x -> GoAwayFrame (s, e, x))
     stream_identifier parse_error_code
     (take (frame_header.length - 8))
 
 let parse_window_frame =
-  lift
-    (fun w ->
-      let w' = clear_bit (Int32.to_int_exn w) 31 in
-      if w' = 0 then
-        Error (ConnectionError (ProtocolError, "window update must not be 0"))
-      else Ok (WindowUpdateFrame w') )
-    BE.any_int32
+  BE.any_int32
+  >>= fun w ->
+  let w' = clear_bit (Int32.to_int_exn w) 31 in
+  if w' = 0 then fail "Window update must not be 0"
+  else return (WindowUpdateFrame w')
 
 let parse_continuation_frame frame_header =
-  lift (fun x -> Ok (ContinuationFrame x)) (take frame_header.length)
+  lift (fun x -> ContinuationFrame x) (take frame_header.length)
 
 let parse_unknown_frame typ frame_header =
-  lift (fun x -> Ok (UnknownFrame (typ, x))) (take frame_header.length)
+  lift (fun x -> UnknownFrame (typ, x)) (take frame_header.length)
 
 let get_parser_for_frame frame_header frame_type =
   match frame_type with
@@ -207,13 +116,18 @@ let get_parser_for_frame frame_header frame_type =
   | FrameContinuation -> parse_continuation_frame frame_header
   | FrameUnknown typ -> parse_unknown_frame typ frame_header
 
-let parse_frame settings =
+let parse_frame_header =
+  lift4
+    (fun length frame_type flags stream_id ->
+      (frame_type, {flags; length; stream_id}) )
+    frame_length frame_type frame_flags stream_identifier
+  <* commit
+
+let parse_frame_payload frame_type frame_header =
+  get_parser_for_frame frame_header frame_type
+
+let parse_frame =
   parse_frame_header
   >>= fun (frame_type, frame_header) ->
-  match check_frame_header settings frame_header frame_type with
-  | Ok frame_header ->
-      get_parser_for_frame frame_header frame_type
-      >>= fun x ->
-      return
-        (Result.map x ~f:(fun frame_payload -> {frame_header; frame_payload}))
-  | Error e -> return (Error e)
+  get_parser_for_frame frame_header frame_type
+  >>| fun frame_payload -> {frame_header; frame_payload}

--- a/frames/lib/parse.mli
+++ b/frames/lib/parse.mli
@@ -1,0 +1,8 @@
+open Types
+
+val parse_frame_header : (frame_type_id * frame_header) Angstrom.t
+
+val parse_frame : frame Angstrom.t
+
+val parse_frame_payload :
+  frame_type_id -> frame_header -> frame_payload Angstrom.t

--- a/frames/test/util.ml
+++ b/frames/test/util.ml
@@ -1,16 +1,13 @@
 open Frames
-open Types
 open Parse
 
 let parse_success wire =
   let req_payload = Hex.to_string (`Hex wire) in
-  match Angstrom.parse_string (parse_frame default_settings) req_payload with
-  | Ok parsed -> (
-    match parsed with Ok frame -> frame | _ -> failwith "ERROR" )
+  match Angstrom.parse_string parse_frame req_payload with
+  | Ok frame -> frame
   | _ -> failwith "ERROR"
 
-let string_of_hex s =
-  Hex.to_string (`Hex s)
+let string_of_hex s = Hex.to_string (`Hex s)
 
 let hex_of_string s =
   let (`Hex hex) = Hex.of_string s in


### PR DESCRIPTION
Remove the header validity. Split the single frame parser into
two separate parsers. One for headers, other for payload. The
user of this parser can perform the error checks needed after parsing
the header, and then feed more input to get the payload.

Closes #10